### PR TITLE
ci: use luuuis/python-semantic-release running on Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,14 @@ jobs:
 
       # Do a dry run of PSR
       - name: Test release
-        uses: luuuis/python-semantic-release@master
+        uses: luuuis/python-semantic-release@a10d5823dfc89d835bad06d8544b22610eafafb5
         if: github.ref_name != 'main'
         with:
           root_options: --noop
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
-        uses: luuuis/python-semantic-release@master
+        uses: luuuis/python-semantic-release@a10d5823dfc89d835bad06d8544b22610eafafb5
         id: release
         if: github.ref_name == 'main'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,14 @@ jobs:
 
       # Do a dry run of PSR
       - name: Test release
-        uses: luuuis/python-semantic-release@main
+        uses: luuuis/python-semantic-release@master
         if: github.ref_name != 'main'
         with:
           root_options: --noop
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
-        uses: luuuis/python-semantic-release@main
+        uses: luuuis/python-semantic-release@master
         id: release
         if: github.ref_name == 'main'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,20 +79,17 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref || github.ref_name }}
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11
+
       # Do a dry run of PSR
       - name: Test release
-        uses: luuuis/python-semantic-release@a12c8c0b7c0c0bda0e45e692da80a1ee1744b125
+        uses: luuuis/python-semantic-release@main
         if: github.ref_name != 'main'
         with:
           root_options: --noop
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
-        uses: luuuis/python-semantic-release@a12c8c0b7c0c0bda0e45e692da80a1ee1744b125
+        uses: luuuis/python-semantic-release@main
         id: release
         if: github.ref_name == 'main'
         with:


### PR DESCRIPTION
Fix for this error in the release action.

```
2024-01-09T17:08:54.1230602Z The currently activated Python version 3.10.13 is not supported by the project (^3.11).
2024-01-09T17:08:54.1231896Z Trying to find and use a compatible version. 
2024-01-09T17:08:54.1727636Z 
2024-01-09T17:08:54.1728562Z Poetry was unable to find a compatible version. If you have one, you can explicitly use it via the "env use" command.
2024-01-09T17:08:54.2182191Z Usage: python -m semantic_release version [OPTIONS]
2024-01-09T17:08:54.2183036Z Try 'python -m semantic_release version -h' for help.
2024-01-09T17:08:54.2183452Z 
2024-01-09T17:08:54.2183929Z Error: Command '['bash', '-c', 'pip install poetry && poetry build']' returned non-zero exit status 1.
```