### PR TITLE
fix: TyperArgument.make_metavar() takes 1 positional argument but 2 were given

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -440,7 +440,7 @@ version = "8.1.8"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "docs", "overrides"]
+groups = ["main", "docs"]
 files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
     {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
@@ -455,12 +455,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev", "docs", "overrides"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\"", overrides = "platform_system == \"Windows\""}
+markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -2323,4 +2323,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "c98f8164eb62203f9956e50975b86f8644064be8b070ce0bb7b25d2d9e39f32d"
+content-hash = "4e153533ad51a9c33490a70e0fc78c2420d23c67448f5bd248a0a42b5ddbf7c1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,8 @@ python = "^3.11"
 rich = ">=10"
 typer = {extras = ["all"], version = ">=0.12,<0.13"}
 aiohttp = "^3.9.1"
-
-[tool.poetry.group.overrides.dependencies]
-# This is needed to use Typer <0.16 (Home Assistant won't accept newer
-# versions due to a transitive dependency).
-# https://github.com/fastapi/typer/discussions/1215
+# Click version constraint needed for Typer <0.13 compatibility
+# Click 8.2.0+ breaks Typer 0.12.x: TyperArgument.make_metavar() signature changed
 click = "<8.2.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Re-do of #28 to fix with the Typer/click incompatibilities. Unfortunately we can't use newest Typer versions due to a conflicting (transitive) dependency in Home Assistant.

```
TypeError: TyperArgument.make_metavar() takes 1 positional argument but 2 were given
```